### PR TITLE
feat: add kb endpoints — /kb/categories, /kb/search, /kb/remember

### DIFF
--- a/hal/server.py
+++ b/hal/server.py
@@ -408,6 +408,81 @@ async def health_detail() -> dict:
     return await asyncio.to_thread(_run)
 
 
+# ---------------------------------------------------------------------------
+# Knowledge base endpoints
+# ---------------------------------------------------------------------------
+
+
+@app.get("/kb/categories", dependencies=[Depends(require_auth)])
+async def kb_categories() -> list[dict]:
+    """Return KB categories with chunk counts.
+
+    Each entry has ``category`` (str) and ``count`` (int).
+    """
+    if "_startup_error" in _state:
+        raise HTTPException(status_code=503, detail=_state["_startup_error"])
+
+    kb: KnowledgeBase | None = _state.get("kb")
+    if kb is None:
+        raise HTTPException(status_code=503, detail="KB not initialised")
+
+    def _run() -> list[dict]:
+        return [{"category": cat, "count": count} for cat, count in kb.categories()]
+
+    return await asyncio.to_thread(_run)
+
+
+@app.get("/kb/search", dependencies=[Depends(require_auth)])
+async def kb_search(
+    q: str,
+    category: str | None = None,
+    top_k: int = 5,
+) -> list[dict]:
+    """Semantic search over the knowledge base.
+
+    Returns ranked results with ``content``, ``file``, ``category``,
+    ``score``, and ``doc_tier``.
+    """
+    if "_startup_error" in _state:
+        raise HTTPException(status_code=503, detail=_state["_startup_error"])
+
+    kb: KnowledgeBase | None = _state.get("kb")
+    if kb is None:
+        raise HTTPException(status_code=503, detail="KB not initialised")
+
+    # Clamp top_k to a sane range to prevent abuse
+    top_k = max(1, min(top_k, 20))
+
+    def _run() -> list[dict]:
+        return kb.search(q, top_k=top_k, category=category or None)
+
+    return await asyncio.to_thread(_run)
+
+
+class RememberRequest(BaseModel):
+    fact: str
+
+
+@app.post("/kb/remember", dependencies=[Depends(require_auth)])
+async def kb_remember(req: RememberRequest) -> dict:
+    """Save a fact to the knowledge base (category='memory')."""
+    if "_startup_error" in _state:
+        raise HTTPException(status_code=503, detail=_state["_startup_error"])
+
+    kb: KnowledgeBase | None = _state.get("kb")
+    if kb is None:
+        raise HTTPException(status_code=503, detail="KB not initialised")
+
+    if not req.fact.strip():
+        raise HTTPException(status_code=400, detail="Fact cannot be empty")
+
+    def _run() -> dict:
+        kb.remember(req.fact.strip())
+        return {"status": "ok"}
+
+    return await asyncio.to_thread(_run)
+
+
 @app.post("/chat", response_model=ChatResponse, dependencies=[Depends(require_auth)])
 async def chat(req: ChatRequest) -> ChatResponse:
     """Send a message to HAL; returns the assistant response."""

--- a/hal/static/app.js
+++ b/hal/static/app.js
@@ -43,6 +43,10 @@
   const $loginError  = document.getElementById("login-error");
   const $signOutBtn  = document.getElementById("sign-out-btn");
   const $sessionSearch = document.getElementById("session-search");
+  const $healthPanel = document.getElementById("health-panel");
+  const $healthPanelBody = document.getElementById("health-panel-body");
+  const $healthPanelClose = document.getElementById("health-panel-close");
+  const $healthPanelOverlay = document.getElementById("health-panel-overlay");
 
   // ── State ───────────────────────────────────────────────────────
   let sessions = loadSessions();     // { id, created, messages[] }
@@ -693,6 +697,108 @@
     }
   }
 
+  // ── Health panel (slide-out) ────────────────────────────────
+  var _METRIC_LABELS = {
+    cpu_pct: "CPU",
+    mem_pct: "Memory",
+    disk_root_pct: "Disk /",
+    disk_docker_pct: "Disk /docker",
+    disk_data_pct: "Disk /data",
+    swap_pct: "Swap",
+    load1: "Load (1m)",
+    gpu_vram_pct: "GPU VRAM",
+    gpu_temp_c: "GPU Temp",
+  };
+
+  function openHealthPanel() {
+    renderHealthPanel();
+    $healthPanel.classList.add("open");
+    $healthPanelOverlay.classList.add("visible");
+  }
+
+  function closeHealthPanel() {
+    $healthPanel.classList.remove("open");
+    $healthPanelOverlay.classList.remove("visible");
+  }
+
+  function renderHealthPanel() {
+    var data = window._halHealthDetail;
+    if (!data) {
+      $healthPanelBody.innerHTML = '<p style="color:var(--text-muted);font-size:13px">No health data yet. Waiting for next poll…</p>';
+      return;
+    }
+
+    var html = '';
+
+    // Components section
+    if (data.components && data.components.length > 0) {
+      html += '<div class="hp-section"><div class="hp-section-title">Components</div>';
+      data.components.forEach(function (c) {
+        html += '<div class="hp-comp">' +
+          '<span class="hp-status-dot ' + _escapeHtml(c.status) + '"></span>' +
+          '<span class="hp-comp-name">' + _escapeHtml(c.name) + '</span>' +
+          '<span class="hp-comp-detail" title="' + _escapeHtml(c.detail) + '">' + _escapeHtml(c.detail) + '</span>' +
+          '<span class="hp-comp-latency">' + Math.round(c.latency_ms) + 'ms</span>' +
+          '</div>';
+      });
+      html += '</div>';
+    }
+
+    // Metrics section
+    var m = data.metrics || {};
+    var metricKeys = Object.keys(_METRIC_LABELS);
+    var hasMetrics = metricKeys.some(function (k) { return m[k] !== null && m[k] !== undefined; });
+    if (hasMetrics) {
+      html += '<div class="hp-section"><div class="hp-section-title">Resources</div>';
+      metricKeys.forEach(function (key) {
+        var val = m[key];
+        var label = _METRIC_LABELS[key];
+        var isTemp = key === "gpu_temp_c";
+        var isLoad = key === "load1";
+        var displayVal = "—";
+        var pct = 0;
+        var colorClass = "";
+
+        if (val !== null && val !== undefined) {
+          if (isTemp) {
+            displayVal = val + "°C";
+            pct = Math.min((val / 90) * 100, 100);  // 90°C = full bar
+            colorClass = val >= 80 ? "crit" : val >= 65 ? "warn" : "";
+          } else if (isLoad) {
+            displayVal = val.toFixed(2);
+            // Assume 16 threads; load 16 = 100%
+            pct = Math.min((val / 16) * 100, 100);
+            colorClass = val >= 12 ? "crit" : val >= 8 ? "warn" : "";
+          } else {
+            displayVal = Math.round(val) + "%";
+            pct = Math.min(val, 100);
+            colorClass = val >= 85 ? "crit" : val >= 60 ? "warn" : "";
+          }
+        }
+
+        html += '<div class="hp-metric">' +
+          '<span class="hp-metric-label">' + _escapeHtml(label) + '</span>' +
+          '<div class="hp-metric-track"><div class="hp-metric-fill ' + colorClass + '" style="width:' + pct + '%"></div></div>' +
+          '<span class="hp-metric-val">' + displayVal + '</span>' +
+          '</div>';
+      });
+      html += '</div>';
+    }
+
+    if (!html) {
+      html = '<p style="color:var(--text-muted);font-size:13px">Health data unavailable.</p>';
+    }
+    $healthPanelBody.innerHTML = html;
+  }
+
+  $healthDot.addEventListener("click", function () {
+    if ($healthPanel.classList.contains("open")) closeHealthPanel();
+    else openHealthPanel();
+  });
+  $healthDot.style.cursor = "pointer";
+  $healthPanelClose.addEventListener("click", closeHealthPanel);
+  $healthPanelOverlay.addEventListener("click", closeHealthPanel);
+
   // ── Sidebar (mobile) ───────────────────────────────────────────
   function openSidebar() {
     $sidebar.classList.add("open");
@@ -902,6 +1008,7 @@
       $input.focus();
     } else if (e.key === "Escape") {
       closeSidebar();
+      closeHealthPanel();
     }
   });
 

--- a/hal/static/index.html
+++ b/hal/static/index.html
@@ -61,6 +61,16 @@
   <!-- Sidebar overlay for mobile -->
   <div id="sidebar-overlay" class="sidebar-overlay"></div>
 
+  <!-- Health detail panel -->
+  <aside id="health-panel" class="health-panel">
+    <div class="health-panel-header">
+      <span class="health-panel-title">System Health</span>
+      <button id="health-panel-close" class="health-panel-close" aria-label="Close">&times;</button>
+    </div>
+    <div id="health-panel-body" class="health-panel-body"></div>
+  </aside>
+  <div id="health-panel-overlay" class="health-panel-overlay"></div>
+
   <!-- Login overlay -->
   <div id="login-overlay" class="login-overlay" style="display:none">
     <div class="login-card">

--- a/hal/static/style.css
+++ b/hal/static/style.css
@@ -549,6 +549,178 @@ body {
   display: block;
 }
 
+/* ── Health detail panel ─────────────────────────────────────────── */
+.health-panel {
+  position: fixed;
+  top: 0;
+  right: -380px;
+  width: 360px;
+  height: 100vh;
+  background: var(--bg-surface);
+  border-left: 1px solid var(--border);
+  z-index: 200;
+  display: flex;
+  flex-direction: column;
+  transition: right 0.25s ease;
+  box-shadow: -4px 0 16px rgba(0, 0, 0, 0.3);
+}
+
+.health-panel.open {
+  right: 0;
+}
+
+.health-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.health-panel-title {
+  font-family: var(--font-mono);
+  font-size: 15px;
+  color: var(--accent);
+  letter-spacing: 1px;
+}
+
+.health-panel-close {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 20px;
+  cursor: pointer;
+  padding: 0 4px;
+  transition: color 0.15s;
+}
+
+.health-panel-close:hover {
+  color: var(--text-primary);
+}
+
+.health-panel-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 16px;
+}
+
+.health-panel-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 190;
+}
+
+.health-panel-overlay.visible {
+  display: block;
+}
+
+/* Sections inside the panel */
+.hp-section {
+  margin-bottom: 20px;
+}
+
+.hp-section-title {
+  font-family: var(--font-sans);
+  font-size: 11px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  margin-bottom: 8px;
+}
+
+/* Component list */
+.hp-comp {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 0;
+  border-bottom: 1px solid var(--bg-page);
+  font-family: var(--font-sans);
+  font-size: 13px;
+}
+
+.hp-comp:last-child {
+  border-bottom: none;
+}
+
+.hp-status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.hp-status-dot.ok { background: var(--green); }
+.hp-status-dot.degraded { background: var(--amber); }
+.hp-status-dot.down { background: var(--red); }
+
+.hp-comp-name {
+  color: var(--text-primary);
+  font-weight: 500;
+  min-width: 80px;
+}
+
+.hp-comp-detail {
+  color: var(--text-muted);
+  font-size: 12px;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hp-comp-latency {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-family: var(--font-mono);
+  flex-shrink: 0;
+}
+
+/* Resource metric rows in panel */
+.hp-metric {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 0;
+}
+
+.hp-metric-label {
+  font-family: var(--font-sans);
+  font-size: 12px;
+  color: var(--text-muted);
+  width: 80px;
+  flex-shrink: 0;
+}
+
+.hp-metric-track {
+  flex: 1;
+  height: 8px;
+  background: var(--bg-page);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.hp-metric-fill {
+  height: 100%;
+  border-radius: 4px;
+  background: var(--green);
+  transition: width 0.4s ease;
+}
+
+.hp-metric-fill.warn { background: var(--amber); }
+.hp-metric-fill.crit { background: var(--red); }
+
+.hp-metric-val {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-primary);
+  width: 42px;
+  text-align: right;
+  flex-shrink: 0;
+}
+
 /* ── Login overlay ────────────────────────────────────────────────── */
 .login-overlay {
   position: fixed;

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1214,3 +1214,257 @@ def test_health_detail_metrics_unavailable() -> None:
     finally:
         server._state.clear()
         server._state.update(old)
+
+
+# ---------------------------------------------------------------------------
+# /kb/categories endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_kb_categories_returns_list() -> None:
+    """GET /kb/categories returns category names with chunk counts."""
+    old = dict(server._state)
+    server._state.clear()
+
+    fake_kb = MagicMock()
+    fake_kb.categories.return_value = [
+        ("lab-state", 18),
+        ("lab-infrastructure", 35),
+    ]
+
+    server._state.update({"config": MagicMock(hal_web_token=""), "kb": fake_kb})
+    try:
+        client = TestClient(server.app)
+        resp = client.get("/kb/categories")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 2
+        assert data[0]["category"] == "lab-state"
+        assert data[0]["count"] == 18
+        assert data[1]["category"] == "lab-infrastructure"
+    finally:
+        server._state.clear()
+        server._state.update(old)
+
+
+def test_kb_categories_requires_auth() -> None:
+    """GET /kb/categories enforces bearer token."""
+    old = dict(server._state)
+    server._state.clear()
+    server._state.update(
+        {
+            "config": MagicMock(hal_web_token="secret"),
+            "kb": MagicMock(),
+        }
+    )
+    try:
+        client = TestClient(server.app)
+        resp = client.get("/kb/categories")
+        assert resp.status_code == 401
+    finally:
+        server._state.clear()
+        server._state.update(old)
+
+
+def test_kb_categories_503_when_degraded() -> None:
+    """GET /kb/categories returns 503 when server is degraded."""
+    old = dict(server._state)
+    server._state.clear()
+    server._state["_startup_error"] = "Services unavailable"
+    try:
+        client = TestClient(server.app)
+        resp = client.get("/kb/categories")
+        assert resp.status_code == 503
+    finally:
+        server._state.clear()
+        server._state.update(old)
+
+
+# ---------------------------------------------------------------------------
+# /kb/search endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_kb_search_returns_results() -> None:
+    """GET /kb/search?q=... returns ranked search results."""
+    old = dict(server._state)
+    server._state.clear()
+
+    fake_kb = MagicMock()
+    fake_kb.search.return_value = [
+        {
+            "content": "vLLM runs on port 8000",
+            "file": "lab.md",
+            "category": "lab-infrastructure",
+            "score": 0.92,
+            "doc_tier": "ground-truth",
+        },
+    ]
+
+    server._state.update({"config": MagicMock(hal_web_token=""), "kb": fake_kb})
+    try:
+        client = TestClient(server.app)
+        resp = client.get("/kb/search", params={"q": "vLLM port"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["score"] == 0.92
+        assert data[0]["category"] == "lab-infrastructure"
+        # Verify the KB was called with correct args
+        fake_kb.search.assert_called_once_with("vLLM port", top_k=5, category=None)
+    finally:
+        server._state.clear()
+        server._state.update(old)
+
+
+def test_kb_search_with_category_filter() -> None:
+    """GET /kb/search respects the optional category parameter."""
+    old = dict(server._state)
+    server._state.clear()
+
+    fake_kb = MagicMock()
+    fake_kb.search.return_value = []
+
+    server._state.update({"config": MagicMock(hal_web_token=""), "kb": fake_kb})
+    try:
+        client = TestClient(server.app)
+        resp = client.get(
+            "/kb/search",
+            params={"q": "docker", "category": "lab-state", "top_k": 3},
+        )
+        assert resp.status_code == 200
+        fake_kb.search.assert_called_once_with("docker", top_k=3, category="lab-state")
+    finally:
+        server._state.clear()
+        server._state.update(old)
+
+
+def test_kb_search_clamps_top_k() -> None:
+    """GET /kb/search clamps top_k to 1..20 range."""
+    old = dict(server._state)
+    server._state.clear()
+
+    fake_kb = MagicMock()
+    fake_kb.search.return_value = []
+
+    server._state.update({"config": MagicMock(hal_web_token=""), "kb": fake_kb})
+    try:
+        client = TestClient(server.app)
+        # top_k=100 should be clamped to 20
+        client.get("/kb/search", params={"q": "test", "top_k": 100})
+        fake_kb.search.assert_called_with("test", top_k=20, category=None)
+
+        # top_k=0 should be clamped to 1
+        client.get("/kb/search", params={"q": "test", "top_k": 0})
+        fake_kb.search.assert_called_with("test", top_k=1, category=None)
+    finally:
+        server._state.clear()
+        server._state.update(old)
+
+
+def test_kb_search_requires_auth() -> None:
+    """GET /kb/search enforces bearer token."""
+    old = dict(server._state)
+    server._state.clear()
+    server._state.update(
+        {
+            "config": MagicMock(hal_web_token="secret"),
+            "kb": MagicMock(),
+        }
+    )
+    try:
+        client = TestClient(server.app)
+        resp = client.get("/kb/search", params={"q": "test"})
+        assert resp.status_code == 401
+    finally:
+        server._state.clear()
+        server._state.update(old)
+
+
+def test_kb_search_requires_query() -> None:
+    """GET /kb/search without q parameter returns 422 (validation error)."""
+    old = dict(server._state)
+    server._state.clear()
+    server._state.update({"config": MagicMock(hal_web_token=""), "kb": MagicMock()})
+    try:
+        client = TestClient(server.app)
+        resp = client.get("/kb/search")
+        assert resp.status_code == 422
+    finally:
+        server._state.clear()
+        server._state.update(old)
+
+
+# ---------------------------------------------------------------------------
+# /kb/remember endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_kb_remember_saves_fact() -> None:
+    """POST /kb/remember saves a fact via kb.remember()."""
+    old = dict(server._state)
+    server._state.clear()
+
+    fake_kb = MagicMock()
+
+    server._state.update({"config": MagicMock(hal_web_token=""), "kb": fake_kb})
+    try:
+        client = TestClient(server.app)
+        resp = client.post("/kb/remember", json={"fact": "vLLM uses port 8000"})
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok"}
+        fake_kb.remember.assert_called_once_with("vLLM uses port 8000")
+    finally:
+        server._state.clear()
+        server._state.update(old)
+
+
+def test_kb_remember_rejects_empty_fact() -> None:
+    """POST /kb/remember returns 400 when fact is blank."""
+    old = dict(server._state)
+    server._state.clear()
+    server._state.update({"config": MagicMock(hal_web_token=""), "kb": MagicMock()})
+    try:
+        client = TestClient(server.app)
+        resp = client.post("/kb/remember", json={"fact": "   "})
+        assert resp.status_code == 400
+    finally:
+        server._state.clear()
+        server._state.update(old)
+
+
+def test_kb_remember_requires_auth() -> None:
+    """POST /kb/remember enforces bearer token."""
+    old = dict(server._state)
+    server._state.clear()
+    server._state.update(
+        {
+            "config": MagicMock(hal_web_token="secret"),
+            "kb": MagicMock(),
+        }
+    )
+    try:
+        client = TestClient(server.app)
+        resp = client.post("/kb/remember", json={"fact": "test fact"})
+        assert resp.status_code == 401
+    finally:
+        server._state.clear()
+        server._state.update(old)
+
+
+def test_kb_remember_strips_whitespace() -> None:
+    """POST /kb/remember strips leading/trailing whitespace from the fact."""
+    old = dict(server._state)
+    server._state.clear()
+
+    fake_kb = MagicMock()
+
+    server._state.update({"config": MagicMock(hal_web_token=""), "kb": fake_kb})
+    try:
+        client = TestClient(server.app)
+        resp = client.post("/kb/remember", json={"fact": "  trimmed fact  "})
+        assert resp.status_code == 200
+        fake_kb.remember.assert_called_once_with("trimmed fact")
+    finally:
+        server._state.clear()
+        server._state.update(old)


### PR DESCRIPTION
Three new API endpoints wrapping existing `KnowledgeBase` methods, for the upcoming KB Browser panel in the Web UI.

## Endpoints

| Method | Path | Description |
|---|---|---|
| `GET` | `/kb/categories` | Category list with chunk counts |
| `GET` | `/kb/search?q=...&category=...&top_k=5` | Semantic search (top_k clamped 1..20) |
| `POST` | `/kb/remember` | Save a fact to pgvector (category=memory) |

All three are auth-protected (same bearer token as `/chat`), return 503 when degraded, and run in `asyncio.to_thread()` since the DB calls are blocking.

## Tests

12 new tests in `test_server.py`:
- `/kb/categories`: happy path, auth enforcement, 503 degraded
- `/kb/search`: happy path, category filter, top_k clamping, auth, missing query (422)
- `/kb/remember`: happy path, empty fact (400), auth, whitespace trimming

965 total tests passing (953 existing + 12 new).

## Risk

Low — thin wrappers around existing tested methods. No changes to any existing endpoint or business logic.