### PR TITLE
feat: add kb browser panel with search and categories

### DIFF
--- a/hal/static/app.js
+++ b/hal/static/app.js
@@ -47,6 +47,14 @@
   const $healthPanelBody = document.getElementById("health-panel-body");
   const $healthPanelClose = document.getElementById("health-panel-close");
   const $healthPanelOverlay = document.getElementById("health-panel-overlay");
+  const $kbBtn            = document.getElementById("kb-btn");
+  const $kbPanel          = document.getElementById("kb-panel");
+  const $kbPanelBody      = document.getElementById("kb-panel-body");
+  const $kbPanelClose     = document.getElementById("kb-panel-close");
+  const $kbPanelOverlay   = document.getElementById("kb-panel-overlay");
+  const $kbSearchInput    = document.getElementById("kb-search-input");
+  const $kbSearchBtn      = document.getElementById("kb-search-btn");
+  const $kbActiveFilter   = document.getElementById("kb-active-filter");
 
   // ── State ───────────────────────────────────────────────────────
   let sessions = loadSessions();     // { id, created, messages[] }
@@ -799,6 +807,172 @@
   $healthPanelClose.addEventListener("click", closeHealthPanel);
   $healthPanelOverlay.addEventListener("click", closeHealthPanel);
 
+  // ── KB Browser panel (slide-out) ────────────────────────────
+  var _kbActiveCategory = null;
+  var _kbCategoriesLoaded = false;
+
+  function openKbPanel() {
+    closeHealthPanel();
+    $kbPanel.classList.add("open");
+    $kbPanelOverlay.classList.add("visible");
+    if (!_kbCategoriesLoaded) loadKbCategories();
+    $kbSearchInput.focus();
+  }
+
+  function closeKbPanel() {
+    $kbPanel.classList.remove("open");
+    $kbPanelOverlay.classList.remove("visible");
+  }
+
+  function loadKbCategories() {
+    $kbPanelBody.innerHTML = '<div class="kb-loading">Loading categories…</div>';
+    fetch(API_BASE + "/kb/categories", { headers: _authHeaders() })
+      .then(function (res) {
+        if (res.status === 401) { showLogin("Session expired"); throw new Error("auth"); }
+        if (!res.ok) throw new Error("HTTP " + res.status);
+        return res.json();
+      })
+      .then(function (data) {
+        _kbCategoriesLoaded = true;
+        renderKbCategories(data);
+      })
+      .catch(function (err) {
+        if (err.message === "auth") return;
+        $kbPanelBody.innerHTML = '<div class="kb-empty">Failed to load categories.</div>';
+      });
+  }
+
+  function renderKbCategories(categories) {
+    if (!categories || categories.length === 0) {
+      $kbPanelBody.innerHTML = '<div class="kb-empty">No categories found.</div>';
+      return;
+    }
+    var html = '';
+    categories.forEach(function (cat) {
+      html += '<div class="kb-cat" data-category="' + _escapeHtml(cat.category) + '">' +
+        '<span class="kb-cat-name">' + _escapeHtml(cat.category) + '</span>' +
+        '<span class="kb-cat-count">' + cat.count + '</span>' +
+        '</div>';
+    });
+    $kbPanelBody.innerHTML = html;
+
+    // Attach click handlers for category filtering
+    var catEls = $kbPanelBody.querySelectorAll(".kb-cat");
+    catEls.forEach(function (el) {
+      el.addEventListener("click", function () {
+        setKbCategoryFilter(el.getAttribute("data-category"));
+      });
+    });
+  }
+
+  function setKbCategoryFilter(category) {
+    _kbActiveCategory = category;
+    $kbActiveFilter.style.display = "flex";
+    $kbActiveFilter.innerHTML =
+      '<span>Category:</span>' +
+      '<span class="kb-filter-tag">' + _escapeHtml(category) + '</span>' +
+      '<button class="kb-filter-clear" title="Clear filter">&times;</button>';
+    $kbActiveFilter.querySelector(".kb-filter-clear").addEventListener("click", clearKbCategoryFilter);
+
+    // If there's already search text, re-run search with filter
+    var q = $kbSearchInput.value.trim();
+    if (q) searchKb(q);
+  }
+
+  function clearKbCategoryFilter() {
+    _kbActiveCategory = null;
+    $kbActiveFilter.style.display = "none";
+    $kbActiveFilter.innerHTML = "";
+
+    // If there's search text, re-run search without filter
+    var q = $kbSearchInput.value.trim();
+    if (q) {
+      searchKb(q);
+    } else {
+      // Show categories again
+      loadKbCategories();
+    }
+  }
+
+  function searchKb(query) {
+    $kbPanelBody.innerHTML = '<div class="kb-loading">Searching…</div>';
+    var url = API_BASE + "/kb/search?q=" + encodeURIComponent(query);
+    if (_kbActiveCategory) url += "&category=" + encodeURIComponent(_kbActiveCategory);
+    fetch(url, { headers: _authHeaders() })
+      .then(function (res) {
+        if (res.status === 401) { showLogin("Session expired"); throw new Error("auth"); }
+        if (!res.ok) throw new Error("HTTP " + res.status);
+        return res.json();
+      })
+      .then(function (data) {
+        renderKbResults(data, query);
+      })
+      .catch(function (err) {
+        if (err.message === "auth") return;
+        $kbPanelBody.innerHTML = '<div class="kb-empty">Search failed.</div>';
+      });
+  }
+
+  function renderKbResults(results, query) {
+    if (!results || results.length === 0) {
+      $kbPanelBody.innerHTML = '<div class="kb-empty">No results for "' + _escapeHtml(query) + '"</div>';
+      return;
+    }
+    var html = '';
+    results.forEach(function (r) {
+      var score = r.score !== null && r.score !== undefined ? r.score.toFixed(3) : "—";
+      var scoreClass = r.score >= 0.85 ? "high" : r.score >= 0.75 ? "mid" : "low";
+      var content = r.content || "";
+      if (content.length > 400) content = content.substring(0, 400) + "…";
+      var file = r.file || "";
+      var category = r.category || "";
+      var tier = r.doc_tier || "";
+
+      html += '<div class="kb-result">' +
+        '<div class="kb-result-header">' +
+          '<span class="kb-result-score ' + scoreClass + '">' + score + '</span>' +
+          (tier ? '<span class="kb-result-tier">' + _escapeHtml(tier) + '</span>' : '') +
+          (file ? '<span class="kb-result-file" title="' + _escapeHtml(file) + '">' + _escapeHtml(file) + '</span>' : '') +
+        '</div>' +
+        '<div class="kb-result-content">' + _escapeHtml(content) + '</div>' +
+        (category ? '<span class="kb-result-category" data-category="' + _escapeHtml(category) + '">' + _escapeHtml(category) + '</span>' : '') +
+        '</div>';
+    });
+    $kbPanelBody.innerHTML = html;
+
+    // Clicking a category badge sets the filter
+    var catBadges = $kbPanelBody.querySelectorAll(".kb-result-category");
+    catBadges.forEach(function (el) {
+      el.addEventListener("click", function () {
+        setKbCategoryFilter(el.getAttribute("data-category"));
+      });
+    });
+  }
+
+  // KB panel event listeners
+  $kbBtn.addEventListener("click", function () {
+    if ($kbPanel.classList.contains("open")) closeKbPanel();
+    else openKbPanel();
+  });
+  $kbPanelClose.addEventListener("click", closeKbPanel);
+  $kbPanelOverlay.addEventListener("click", closeKbPanel);
+  $kbSearchBtn.addEventListener("click", function () {
+    var q = $kbSearchInput.value.trim();
+    if (q) searchKb(q);
+  });
+  $kbSearchInput.addEventListener("keydown", function (e) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      var q = $kbSearchInput.value.trim();
+      if (q) searchKb(q);
+      else {
+        // Empty search → show categories
+        clearKbCategoryFilter();
+        loadKbCategories();
+      }
+    }
+  });
+
   // ── Sidebar (mobile) ───────────────────────────────────────────
   function openSidebar() {
     $sidebar.classList.add("open");
@@ -1009,6 +1183,7 @@
     } else if (e.key === "Escape") {
       closeSidebar();
       closeHealthPanel();
+      closeKbPanel();
     }
   });
 

--- a/hal/static/index.html
+++ b/hal/static/index.html
@@ -22,6 +22,7 @@
     <div class="sidebar-header">
       <span class="sidebar-brand">HAL</span>
       <span id="health-dot" class="health-dot" title="Checking..."></span>
+      <button id="kb-btn" class="kb-btn" title="Knowledge Base">KB</button>
     </div>
     <button id="new-session-btn" class="new-session-btn">+ New Session</button>
     <input id="session-search" class="session-search" type="text" placeholder="search sessions…">
@@ -60,6 +61,21 @@
 
   <!-- Sidebar overlay for mobile -->
   <div id="sidebar-overlay" class="sidebar-overlay"></div>
+
+  <!-- KB Browser panel -->
+  <aside id="kb-panel" class="kb-panel">
+    <div class="kb-panel-header">
+      <span class="kb-panel-title">Knowledge Base</span>
+      <button id="kb-panel-close" class="kb-panel-close" aria-label="Close">&times;</button>
+    </div>
+    <div class="kb-search-bar">
+      <input id="kb-search-input" class="kb-search-input" type="text" placeholder="semantic search…">
+      <button id="kb-search-btn" class="kb-search-btn" aria-label="Search">&#x279C;</button>
+    </div>
+    <div id="kb-active-filter" class="kb-active-filter" style="display:none"></div>
+    <div id="kb-panel-body" class="kb-panel-body"></div>
+  </aside>
+  <div id="kb-panel-overlay" class="kb-panel-overlay"></div>
 
   <!-- Health detail panel -->
   <aside id="health-panel" class="health-panel">

--- a/hal/static/style.css
+++ b/hal/static/style.css
@@ -721,6 +721,312 @@ body {
   flex-shrink: 0;
 }
 
+/* ── KB trigger button (sidebar header) ──────────────────────────── */
+.kb-btn {
+  margin-left: auto;
+  background: var(--badge-bg);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  padding: 2px 8px;
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+  letter-spacing: 1px;
+}
+
+.kb-btn:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+/* ── KB Browser panel ────────────────────────────────────────────── */
+.kb-panel {
+  position: fixed;
+  top: 0;
+  right: -420px;
+  width: 400px;
+  height: 100vh;
+  background: var(--bg-surface);
+  border-left: 1px solid var(--border);
+  z-index: 200;
+  display: flex;
+  flex-direction: column;
+  transition: right 0.25s ease;
+  box-shadow: -4px 0 16px rgba(0, 0, 0, 0.3);
+}
+
+.kb-panel.open {
+  right: 0;
+}
+
+.kb-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.kb-panel-title {
+  font-family: var(--font-mono);
+  font-size: 15px;
+  color: var(--accent);
+  letter-spacing: 1px;
+}
+
+.kb-panel-close {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 20px;
+  cursor: pointer;
+  padding: 0 4px;
+  transition: color 0.15s;
+}
+
+.kb-panel-close:hover {
+  color: var(--text-primary);
+}
+
+.kb-search-bar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.kb-search-input {
+  flex: 1;
+  background: var(--bg-page);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text-primary);
+  font-family: var(--font-sans);
+  font-size: 13px;
+  padding: 7px 10px;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.kb-search-input:focus {
+  border-color: var(--accent);
+}
+
+.kb-search-input::placeholder {
+  color: var(--text-muted);
+}
+
+.kb-search-btn {
+  background: var(--accent);
+  border: none;
+  color: var(--bg-page);
+  font-size: 14px;
+  font-weight: 600;
+  width: 30px;
+  height: 30px;
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background 0.15s;
+  flex-shrink: 0;
+}
+
+.kb-search-btn:hover {
+  background: var(--accent-hover);
+}
+
+.kb-active-filter {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 16px;
+  background: var(--bg-page);
+  font-family: var(--font-sans);
+  font-size: 12px;
+  color: var(--text-muted);
+  border-bottom: 1px solid var(--border);
+}
+
+.kb-filter-tag {
+  background: var(--badge-bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 2px 8px;
+  color: var(--accent);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.kb-filter-clear {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 14px;
+  padding: 0 2px;
+  transition: color 0.15s;
+}
+
+.kb-filter-clear:hover {
+  color: var(--red);
+}
+
+.kb-panel-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 16px;
+}
+
+.kb-panel-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 190;
+}
+
+.kb-panel-overlay.visible {
+  display: block;
+}
+
+/* Category list */
+.kb-cat {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 10px;
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background 0.12s;
+  font-family: var(--font-sans);
+  font-size: 13px;
+}
+
+.kb-cat:hover {
+  background: var(--bg-page);
+}
+
+.kb-cat-name {
+  color: var(--text-primary);
+}
+
+.kb-cat-count {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  background: var(--badge-bg);
+  padding: 1px 6px;
+  border-radius: var(--radius);
+}
+
+/* Search results */
+.kb-result {
+  padding: 10px 0;
+  border-bottom: 1px solid var(--bg-page);
+}
+
+.kb-result:last-child {
+  border-bottom: none;
+}
+
+.kb-result-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 4px;
+}
+
+.kb-result-score {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-weight: 500;
+}
+
+.kb-result-score.high {
+  background: rgba(63, 185, 80, 0.15);
+  color: var(--green);
+}
+
+.kb-result-score.mid {
+  background: rgba(210, 153, 34, 0.15);
+  color: var(--amber);
+}
+
+.kb-result-score.low {
+  background: rgba(248, 81, 73, 0.15);
+  color: var(--red);
+}
+
+.kb-result-tier {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.kb-result-file {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-left: auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 160px;
+}
+
+.kb-result-content {
+  font-family: var(--font-sans);
+  font-size: 12px;
+  color: var(--text-primary);
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 120px;
+  overflow: hidden;
+  position: relative;
+}
+
+.kb-result-category {
+  display: inline-block;
+  margin-top: 4px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--accent);
+  background: rgba(88, 166, 255, 0.1);
+  padding: 1px 6px;
+  border-radius: 3px;
+  cursor: pointer;
+  transition: background 0.12s;
+}
+
+.kb-result-category:hover {
+  background: rgba(88, 166, 255, 0.2);
+}
+
+/* Loading / empty states */
+.kb-loading {
+  text-align: center;
+  padding: 24px 0;
+  color: var(--text-muted);
+  font-size: 13px;
+  font-family: var(--font-sans);
+}
+
+.kb-empty {
+  text-align: center;
+  padding: 24px 0;
+  color: var(--text-muted);
+  font-size: 13px;
+  font-family: var(--font-sans);
+}
+
 /* ── Login overlay ────────────────────────────────────────────────── */
 .login-overlay {
   position: fixed;
@@ -1254,5 +1560,17 @@ pre:hover .copy-btn {
 
   .input-area {
     padding: 8px 12px 12px;
+  }
+
+  /* Health panel full-width on mobile */
+  .health-panel {
+    width: 100vw;
+    right: -100vw;
+  }
+
+  /* KB panel full-width on mobile */
+  .kb-panel {
+    width: 100vw;
+    right: -100vw;
   }
 }


### PR DESCRIPTION
## Step 5 — KB Browser Panel

Adds a slide-out Knowledge Base browser to the Web UI, matching the existing health panel pattern.

### What it does

- **KB button** in the sidebar header opens a right-side slide-out panel
- On first open, loads all KB categories from `GET /kb/categories` with chunk counts
- **Category click** sets an active filter (shown as a dismissible chip above results)
- **Semantic search** via the search bar hits `GET /kb/search` with optional category filter
- **Result cards** show: score badge (color-coded green/amber/red by similarity), doc tier label, file path, and content preview (truncated to 400 chars)
- Category badges on result cards are clickable to quickly filter by that category
- **Dismissal**: Escape key, close button (×), and backdrop overlay all close the panel
- **Mobile**: full-width panel on screens ≤768px

### Files changed

| File | What changed |
|---|---|
| `hal/static/index.html` | KB button in sidebar header, KB panel markup (search bar, filter chip, body), overlay |
| `hal/static/style.css` | ~250 lines: `.kb-btn`, `.kb-panel`, search bar, category rows, result cards, score badges, filter chip, loading/empty states, mobile breakpoint |
| `hal/static/app.js` | ~160 lines: DOM refs, `openKbPanel`/`closeKbPanel`, `loadKbCategories`, `searchKb`, `renderKbResults`, category filter state, event listeners, Escape handler |

### Testing

- All 965 offline tests passing
- `ruff check` clean
- Frontend-only changes — no backend modifications needed (endpoints from PR #5)

### UX flow

1. Click **KB** button in sidebar → panel slides in from right
2. Categories listed with chunk counts → click one to filter
3. Type a query in the search bar → Enter or click arrow → results appear
4. Click a category badge on any result → sets that as active filter
5. Dismiss filter chip → returns to unfiltered view
6. Escape / × / overlay → panel closes