### PR TITLE
feat: auto-authenticate from url token parameter

### DIFF
--- a/hal/static/app.js
+++ b/hal/static/app.js
@@ -1224,6 +1224,19 @@
 
   // ── Init ────────────────────────────────────────────────────────
   (function init() {
+    // Auto-authenticate from URL token (e.g. ?token=xxx) — store and strip
+    var _urlParams = new URLSearchParams(window.location.search);
+    var _urlToken = _urlParams.get("token");
+    if (_urlToken) {
+      _token = _urlToken;
+      localStorage.setItem(TOKEN_KEY, _token);
+      // Remove token from the URL so it doesn't leak in history/screenshots
+      _urlParams.delete("token");
+      var _cleanUrl = window.location.pathname;
+      if (_urlParams.toString()) _cleanUrl += "?" + _urlParams.toString();
+      window.history.replaceState({}, "", _cleanUrl);
+    }
+
     // Ensure at least one session exists
     if (sessions.length === 0 || !getActive()) {
       createSession();


### PR DESCRIPTION
## URL Token Auto-Authentication

Adds `?token=xxx` URL parameter support so you can bookmark the URL once and never type the token again.

### How it works

1. On page load, checks `window.location.search` for a `token` param
2. If found, stores it in `localStorage` (same as the login form does)
3. Strips the `?token=` from the URL via `history.replaceState` — so it doesn't appear in browser history, screenshots, or the address bar after load
4. The existing auth probe then sees `_token` is already set and skips the login overlay

### Usage

Bookmark: `http://192.168.5.10:8087/?token=YOUR_TOKEN_HERE`

Every visit auto-authenticates. No login screen.

### Files changed

| File | Change |
|---|---|
| `hal/static/app.js` | +13 lines in `init()` — URL param extraction + cleanup |

### Testing

- 53 server tests passing
- No backend changes