### PR TITLE
chore: lower vLLM gpu-memory-utilization from 0.95 to 0.90

### DIFF
--- a/ops/vllm.service
+++ b/ops/vllm.service
@@ -13,7 +13,7 @@ ExecStart=/home/jp/vllm-env/bin/vllm serve Qwen/Qwen2.5-32B-Instruct-AWQ \
     --port 8000 \
     --enforce-eager \
     --max-model-len 8192 \
-    --gpu-memory-utilization 0.95
+    --gpu-memory-utilization 0.90
 Restart=always
 RestartSec=10
 StandardOutput=journal


### PR DESCRIPTION
## What

Lowers vLLM's `--gpu-memory-utilization` from `0.95` to `0.90` in `ops/vllm.service`.

## Why

Frees ~800 MiB VRAM headroom on the RTX 3090 Ti. The model weights (~16-17 GB AWQ) fit comfortably at 0.90; savings come from a smaller KV cache pre-allocation, which is fine for single-user workloads.

Combined with Change #1 (Ollama `CUDA_VISIBLE_DEVICES=\"\"` — applied server-side only, not in this repo), this gives the GPU more breathing room.

## Verification

Already applied and verified on the server:

| Metric | Before | After |
|---|---|---|
| VRAM used | 22,910 MiB | 22,108 MiB |
| VRAM free | 1,204 MiB | 2,006 MiB |
| vLLM health | HTTP 200 | HTTP 200 |
| HAL health | ok | ok |
| Ollama embeddings | 768 dims | 768 dims |
| HAL inference | — | Working (\"Four\" for 2+2) |

## Rollback

Change `0.90` back to `0.95` in `ops/vllm.service`, then on server:
```bash
cp ops/vllm.service ~/.config/systemd/user/vllm.service
systemctl --user daemon-reload && systemctl --user restart vllm.service
```